### PR TITLE
Use @abandonware/i2c

### DIFF
--- a/install-i2c.sh
+++ b/install-i2c.sh
@@ -1,4 +1,4 @@
 echo "Installing i2c dependency..."
 echo "This will ONLY work on a Linux OS such as the Rasperberry Pi"
 echo ""
-npm install i2c@0.2.3
+npm install @abandonware/i2c@0.2.4-0

--- a/src/i2cWrapper.js
+++ b/src/i2cWrapper.js
@@ -9,7 +9,7 @@ export default function makeI2CWrapper(address, {device, debug}, isMockDriver) {
   // This allows to compile on a non Linux OS
   let i2c = null;
   if (!isMockDriver) {
-    const I2C = require('i2c');
+    const I2C = require('@abandonware/i2c');
     i2c = new I2C(address, {device});
   }
 


### PR DESCRIPTION
`i2c` doesn't support Node 10+, but an `@abandonware` package has been created and this works fine with your fork of adafruit-i2c-pwm-driver.

Not sure if you want to go down this route with this fork but here it is ;-)